### PR TITLE
Update TriggerDataDecoderConfig

### DIFF
--- a/configfiles/PreProcessTrigOverlap/TriggerDataDecoderConfig
+++ b/configfiles/PreProcessTrigOverlap/TriggerDataDecoderConfig
@@ -1,5 +1,5 @@
 verbosity 0
 #TriggerMaskFile ./configfiles/EventBuilder/DefaultTriggerMask.txt
-StoreTrigOverlap 1
+StoreTrigOverlap 0
 ReadTrigOverlap 0
 UseCStore 0


### PR DESCRIPTION
this shouldnt make a difference but the traditional tools had this variable as 0, and set it as 1 in the LoadRawData tool