### PR TITLE
Fix a bug about NumWavesInCompleteSet in EBPMT

### DIFF
--- a/UserTools/EBPMT/EBPMT.cpp
+++ b/UserTools/EBPMT/EBPMT.cpp
@@ -26,8 +26,8 @@ bool EBPMT::Initialise(std::string configfile, DataModel &data)
   NumWavesInCompleteSet = 140;
 
   FinishedHits = new std::map<uint64_t, std::map<unsigned long, std::vector<Hit>> *>();
-  RWMRawWaveforms = new std::map<uint64_t, std::vector<uint16_t>>();
-  BRFRawWaveforms = new std::map<uint64_t, std::vector<uint16_t>>();
+  //RWMRawWaveforms = new std::map<uint64_t, std::vector<uint16_t>>();
+  //BRFRawWaveforms = new std::map<uint64_t, std::vector<uint16_t>>();
 
   saveRWMWaveforms = true;
   saveBRFWaveforms = true;
@@ -43,10 +43,14 @@ bool EBPMT::Execute()
   bool gotHits = m_data->CStore.Get("InProgressHits", InProgressHits);
   bool gotChkey = m_data->CStore.Get("InProgressChkey", InProgressChkey);
 
-  m_data->CStore.Get("RWMRawWaveforms", RWMRawWaveforms);
-  m_data->CStore.Get("BRFRawWaveforms", BRFRawWaveforms);
-  Log("EBPMT: Got RWMRawWaveforms size: " + std::to_string(RWMRawWaveforms->size()), v_message, verbosityEBPMT);
-  Log("EBPMT: Got BRFRawWaveforms size: " + std::to_string(BRFRawWaveforms->size()), v_message, verbosityEBPMT);
+    if (!gotHits || !gotChkey)
+  {
+    Log("EBPMT: No InProgressHits or InProgressChkey found", v_message, verbosityEBPMT);
+    return true;
+  }
+  Log("EBPMT: got inprogress hits and chkey with size " + std::to_string(InProgressHits->size()) + " and " + std::to_string(InProgressChkey->size()), v_message, verbosityEBPMT);
+
+
 
   if (exeNum % 80 == 0 && exeNum != 0)
   {
@@ -72,14 +76,19 @@ bool EBPMT::Execute()
   Log("EBPMT: Got PairedPMTTimeStamps size: " + std::to_string(PairedPMTTimeStamps.size()), v_message, verbosityEBPMT);
   Log("EBPMT: Got PairedPMTTriggerTimestamp size: " + std::to_string(PairedCTCTimeStamps.size()), v_message, verbosityEBPMT);
 
-  Log("EBPMT: gotHits = " + std::to_string(gotHits) + " gotChkey = " + std::to_string(gotChkey), v_message, verbosityEBPMT);
-  if (!gotHits || !gotChkey)
-  {
-    Log("EBPMT: No InProgressHits or InProgressChkey found", v_message, verbosityEBPMT);
-    return true;
-  }
 
-  Log("EBPMT: got inprogress hits and chkey with size " + std::to_string(InProgressHits->size()) + " and " + std::to_string(InProgressChkey->size()), v_message, verbosityEBPMT);
+
+    bool gotRWM = m_data->CStore.Get("RWMRawWaveforms", RWMRawWaveforms);
+  bool gotBRF = m_data->CStore.Get("BRFRawWaveforms", BRFRawWaveforms);
+  if (gotRWM && gotBRF && RWMRawWaveforms != NULL && BRFRawWaveforms != NULL)
+  {
+    Log("EBPMT: Got RWMRawWaveforms size: " + std::to_string(RWMRawWaveforms->size()), v_message, verbosityEBPMT);
+    Log("EBPMT: Got BRFRawWaveforms size: " + std::to_string(BRFRawWaveforms->size()), v_message, verbosityEBPMT);
+  }
+  else
+  {
+    Log("EBPMT: No RWMRawWaveforms or BRFRawWaveforms found", v_message, verbosityEBPMT);
+  }
 
   vector<uint64_t> PMTEmplacedHitTimes;
   vector<uint64_t> RWMEmplacedTimes;
@@ -109,7 +118,7 @@ bool EBPMT::Execute()
     if (MaxObservedNumWaves > NumWavesInCompleteSet)
       NumWavesInCompleteSet = MaxObservedNumWaves;
 
-    if (ChannelKey.size() == (NumWavesInCompleteSet - 1))
+    if (ChannelKey.size() >= (NumWavesInCompleteSet - 10))
     {
       Log("EBPMT: ChannelKey.size() == (NumWavesInCompleteSet - 1), ChannelKey.size() = " + std::to_string(ChannelKey.size()) + " == NumWavesInCompleteSet - 1 = " + std::to_string(NumWavesInCompleteSet - 1), v_debug, verbosityEBPMT);
       if (AlmostCompleteWaveforms.find(PMTCounterTimeNs) != AlmostCompleteWaveforms.end())
@@ -122,7 +131,7 @@ bool EBPMT::Execute()
       Log("EBPMT: AlmostCompleteWaveforms adding PMTCounterTimeNs = " + std::to_string(PMTCounterTimeNs) + " to " + std::to_string(AlmostCompleteWaveforms[PMTCounterTimeNs]), v_debug, verbosityEBPMT);
     }
 
-    Log("EBPMT: ChannelKey.size() = " + std::to_string(ChannelKey.size()) + " >= NumWavesInCompleteSet = " + std::to_string(NumWavesInCompleteSet) + " or AlmostCompleteWaveforms.at(PMTCounterTimeNs) = " + std::to_string(AlmostCompleteWaveforms[PMTCounterTimeNs] >= 5), v_debug, verbosityEBPMT);
+    //Log("EBPMT: ChannelKey.size() = " + std::to_string(ChannelKey.size()) + " >= NumWavesInCompleteSet = " + std::to_string(NumWavesInCompleteSet) + " or AlmostCompleteWaveforms.at(PMTCounterTimeNs) = " + std::to_string(AlmostCompleteWaveforms[PMTCounterTimeNs] >= 5), v_debug, verbosityEBPMT);
 
 
     // print all elements in vector<unsigned long> ChannelKey
@@ -132,9 +141,15 @@ bool EBPMT::Execute()
 //      cout<<ch<<", ";
 //    }
 //    cout<<endl;
+auto it_acw = AlmostCompleteWaveforms.find(PMTCounterTimeNs);
+    int AlmostCompleteWaveforms_CountHere = 0;
+    if (it_acw != AlmostCompleteWaveforms.end())
+    {
+      AlmostCompleteWaveforms_CountHere = it_acw->second;
+    }
 
 
-    if (ChannelKey.size() >= NumWavesInCompleteSet || ((ChannelKey.size() == NumWavesInCompleteSet - 1) && (AlmostCompleteWaveforms[PMTCounterTimeNs] >= 5)))
+    if (ChannelKey.size() >= NumWavesInCompleteSet || ((ChannelKey.size() == NumWavesInCompleteSet - 1) && (AlmostCompleteWaveforms_CountHere >= 5)))
     {
       Log("EBPMT: Emplace hit map to FinishedHits, ChannelKey.size() = " + std::to_string(ChannelKey.size()) + " >= NumWavesInCompleteSet = " + std::to_string(NumWavesInCompleteSet) + " or AlmostCompleteWaveforms.at(PMTCounterTimeNs) = " + std::to_string(AlmostCompleteWaveforms.at(PMTCounterTimeNs) >= 5), v_debug, verbosityEBPMT);
 
@@ -322,9 +337,13 @@ bool EBPMT::Matching(int targetTrigger, int matchToTrack)
     Log("EBPMT: looping hit " + std::to_string(loopNum) + ", minDT: " + std::to_string(minDT) + ", minDTTrigger time: " + std::to_string(minDTTrigger) + " with word " + std::to_string(matchedTrigWord) + ", in trigger track " + std::to_string(matchedTrack), v_warning, verbosityEBPMT);
     if (minDT < matchTolerance_ns)
     {
-      PairedCTCTimeStamps[matchedTrack].push_back(minDTTrigger);
-      PairedPMTTimeStamps[matchedTrack].push_back(PMTCounterTimeNs);
-      PairedPMT_TriggerIndex[matchedTrack].push_back(matchedIndex);
+      //PairedCTCTimeStamps[matchedTrack].push_back(minDTTrigger);
+      //PairedPMTTimeStamps[matchedTrack].push_back(PMTCounterTimeNs);
+      //PairedPMT_TriggerIndex[matchedTrack].push_back(matchedIndex);
+
+      PairedCTCTimeStamps.emplace(matchedTrack, std::vector<uint64_t>{}).first->second.push_back(minDTTrigger);
+      PairedPMTTimeStamps.emplace(matchedTrack, std::vector<uint64_t>{}).first->second.push_back(PMTCounterTimeNs);
+      PairedPMT_TriggerIndex.emplace(matchedTrack, std::vector<int>{}).first->second.push_back(matchedIndex);
 
       // the pmt hit map with timestmap PMTCounterTimeNs, match to trigger with timestamp minDTTrigger
       // the matched trigger is at matchedIndex of that trigger track

--- a/configfiles/LAPPD_EB/Configs
+++ b/configfiles/LAPPD_EB/Configs
@@ -18,7 +18,7 @@ BoardIndexLabel BoardIndex #Label of the vector of read out boards
 PsecReceiveMode 1
 stopEntries 10000000000
 
-DoPedSubtraction 1
+DoPedSubtraction 0
 Nboards 6 #Number of pedestal files to be read in
 PedinputfileTXT ../Pedestals/Laser2024Feb/P
 PSECinputfile /pnfs/annie/persistent/processed/LAPPD40Merged/FinalVersion_withRawTS/FilteredData_PMT_MRDtrack_noveto_15mV_7strips_3xxx_104


### PR DESCRIPTION
Previously, if NumWavesInCompleteSet was set to 140 and there are only ~133 PMT waveforms exist in data, the AlmostCompleteWaveforms[PMTCounterTimeNs] won't be created. But the usage of AlmostCompleteWaveforms[PMTCounterTimeNs] in Log will create an entry there. This won't affect the later code because there are checks to require AlmostCompleteWaveforms[PMTCounterTimeNs] > 5.

Now the Log was removed and the tolerance for PMT number is changed to 10 at: ChannelKey.size() >= (NumWavesInCompleteSet - 10)

Also change the pedestal subtraction for LAPPD_EB tool chain to be 0.